### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ import FS from '@isomorphic-git/lightning-fs';
 const fs = new FS("testfs")
 ```
 
+**Note: do not create multiple `fs` instances using the same name.** If you do, you'll have two distinct FileSystems both fighting over the same IndexedDb store.
+
 Options object:
 
 | Param  | Type [= default]   | Description                                                           |

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -79,7 +79,7 @@ module.exports = function (config) {
         platformName: 'iOS',
         platformVersion: '11.2',
         browserName: 'Safari',
-        appiumVersion: '1.7.2'
+        appiumVersion: '1.9.1'
       },
       sl_android_chrome: {
         base: 'SauceLabs',
@@ -87,7 +87,7 @@ module.exports = function (config) {
         platformName: 'Android',
         platformVersion: '7.1',
         browserName: 'Chrome',
-        appiumVersion: '1.7.2'
+        appiumVersion: '1.9.1'
       },
       FirefoxHeadless: {
         base: 'Firefox',


### PR DESCRIPTION
close #16

@hsablonniere What do you think? Would this warning have been enough to save you from the issue you ran into? I'd be happy to change the appearance (make it red? highlight it?) or wording, or consider more technical solutions.

The main issue with a technical solution, is really it's 100% OK to create multiple instances using the same IndexedDB store _as long as they aren't being used at the same time_. For instance, one might have a "Wipe FS" button that performs:

```js
fs = new FS('cool-app')

$('#wipeButton').on('click', () => {
  fs = new FS('cool-app', {wipe: true})
})
```

(whoa.... it felt _weird_ to write jQuery-esque code. I've been in React-world too long.)

Or another realistic scenario is running `fs = new FS('test', {wipe: true})` for each test in a test suite, but then the tests run in serial and the `fs` variable gets garbage collected between tests.