### PR TITLE
fix(HttpBackend): fs.readFile should throw on 404s

### DIFF
--- a/src/HttpBackend.js
+++ b/src/HttpBackend.js
@@ -5,7 +5,12 @@ module.exports = class HttpBackend {
   loadSuperblock() {
     return fetch(this._url + '/.superblock.txt').then(res => res.text())
   }
-  readFile(filepath) {
-    return fetch(this._url + filepath).then(res => res.arrayBuffer())
+  async readFile(filepath) {
+    const res = await fetch(this._url + filepath)
+    if (res.status === 200) {
+      return res.arrayBuffer()
+    } else {
+      throw new Error('ENOENT')
+    }
   }
 }


### PR DESCRIPTION
There's actually a more serious underlying race condition I think, where readFile and writeFile for the same file are interleaved, but at least for running the isomorphic-git test cases, this is sufficient.