### PR TITLE
fix(unlink): deleting symlinks should not delete file contents

### DIFF
--- a/src/PromisifiedFS.js
+++ b/src/PromisifiedFS.js
@@ -172,9 +172,11 @@ module.exports = class PromisifiedFS {
   }
   async unlink(filepath, opts) {
     ;[filepath, opts] = cleanParams(filepath, opts);
-    const stat = this._cache.stat(filepath);
+    const stat = this._cache.lstat(filepath);
     this._cache.unlink(filepath);
-    await this._idb.unlink(stat.ino)
+    if (stat.type !== 'symlink') {
+      await this._idb.unlink(stat.ino)
+    }
     return null
   }
   async readdir(filepath, opts) {

--- a/src/__tests__/fs.promises.spec.js
+++ b/src/__tests__/fs.promises.spec.js
@@ -346,7 +346,10 @@ describe("fs.promises module", () => {
                   fs.readdir("/symlink/del").then(data => {
                     expect(data.includes("file.txt")).toBe(true)
                     expect(data.includes("file2.txt")).toBe(false)
-                    done();
+                    fs.readFile("/symlink/del/file.txt", "utf8").then(data => {
+                      expect(data).toBe("data")
+                      done();
+                    })
                   });
                 });
               });

--- a/src/__tests__/fs.spec.js
+++ b/src/__tests__/fs.spec.js
@@ -377,7 +377,11 @@ describe("fs module", () => {
                     expect(err).toBe(null)
                     expect(data.includes("file.txt")).toBe(true)
                     expect(data.includes("file2.txt")).toBe(false)
-                    done();
+                    fs.readFile("/symlink/del/file.txt", "utf8", (err, data) => {
+                      expect(err).toBe(null)
+                      expect(data).toBe("data")
+                      done();
+                    })
                   });
                 });
               });


### PR DESCRIPTION
It was tricky to spot, because it didn't delete the inode, just the underlying file contents.