### PR TITLE
backFile(): add http-backed files to superblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ const fs = new FS("testfs")
 
 Options object:
 
-| Param  | Type [= default]   | Description                                                           |
-| ------ | ------------------ | --------------------------------------------------------------------- |
-| `wipe` | boolean = false    | Delete the database and start with an empty filesystem                |
-| `url`  | string = undefined | Let `readFile` requests fall back to an HTTP request to this base URL |
+| Param     | Type [= default]   | Description                                                           |
+| --------- | ------------------ | --------------------------------------------------------------------- |
+| `wipe`    | boolean = false    | Delete the database and start with an empty filesystem                |
+| `url`     | string = undefined | Let `readFile` requests fall back to an HTTP request to this base URL |
+| `urlauto` | boolean = false    | Fall back to HTTP for every read of a missing file, even if unbacked  |
 
 ### `fs.mkdir(filepath, opts?, cb)`
 
@@ -148,6 +149,17 @@ Create a symlink at `filepath` that points to `target`.
 ### `fs.readlink(filepath, opts?, cb)`
 
 Read the target of a symlink.
+
+### `fs.backFile(filepath, opts?, cb)`
+
+Create or change the stat data for a file backed by HTTP.  Size is fetched with a HEAD request.  Useful when using an HTTP backend without `urlauto` set, as then files will only be readable if they have stat data.
+Note that stat data is made automatically from the file `/.superblock.txt` if found on the server.  `/.superblock.txt` can be generated or updated with the [included standalone script](src/superblocktxt.js).
+
+Options object:
+
+| Param      | Type [= default]   | Description                      |
+| ---------- | ------------------ | -------------------------------- |
+| `mode`     | number = 0o666     | Posix mode permissions           |
 
 ### `fs.promises`
 

--- a/src/CacheFS.js
+++ b/src/CacheFS.js
@@ -160,7 +160,7 @@ module.exports = class CacheFS {
     let dir = this._lookup(filepath);
     return [...dir.keys()].filter(key => typeof key === "string");
   }
-  writeFile(filepath, data, { mode }) {
+  writeStat(filepath, size, { mode }) {
     let ino;
     try {
       let oldStat = this.stat(filepath);
@@ -180,7 +180,7 @@ module.exports = class CacheFS {
     let stat = {
       mode,
       type: "file",
-      size: data.length,
+      size,
       mtimeMs: Date.now(),
       ino,
     };

--- a/src/HttpBackend.js
+++ b/src/HttpBackend.js
@@ -3,12 +3,20 @@ module.exports = class HttpBackend {
     this._url = url;
   }
   loadSuperblock() {
-    return fetch(this._url + '/.superblock.txt').then(res => res.text())
+    return fetch(this._url + '/.superblock.txt').then(res => res.ok ? res.text() : null)
   }
   async readFile(filepath) {
     const res = await fetch(this._url + filepath)
     if (res.status === 200) {
       return res.arrayBuffer()
+    } else {
+      throw new Error('ENOENT')
+    }
+  }
+  async sizeFile(filepath) {
+    const res = await fetch(this._url + filepath, { method: 'HEAD' })
+    if (res.status === 200) {
+      return res.headers.get('content-length')
     } else {
       throw new Error('ENOENT')
     }

--- a/src/__tests__/CacheFS.spec.js
+++ b/src/__tests__/CacheFS.spec.js
@@ -21,7 +21,7 @@ describe("CacheFS module", () => {
     const fs = new CacheFS();
     fs.activate()
     expect(fs.autoinc()).toEqual(1)
-    fs.writeFile('/foo', 'bar', {})
+    fs.writeStat('/foo', 3, {})
     expect(fs.autoinc()).toEqual(2)
     fs.mkdir('/bar', {})
     expect(fs.autoinc()).toEqual(3)
@@ -33,7 +33,7 @@ describe("CacheFS module", () => {
     expect(fs.autoinc()).toEqual(3)
     fs.mkdir('/bar/bar', {})
     expect(fs.autoinc()).toEqual(4)
-    fs.writeFile('/bar/bar/boo', 'bar', {})
+    fs.writeStat('/bar/bar/boo', 3, {})
     expect(fs.autoinc()).toEqual(5)
     fs.unlink('/bar/bar/boo')
     expect(fs.autoinc()).toEqual(4)

--- a/src/__tests__/__fixtures__/test-folder/not-in-superblock.txt
+++ b/src/__tests__/__fixtures__/test-folder/not-in-superblock.txt
@@ -1,0 +1,1 @@
+Hello from "not-in-superblock"

--- a/src/__tests__/fallback.spec.js
+++ b/src/__tests__/fallback.spec.js
@@ -38,6 +38,12 @@ describe("http fallback", () => {
         done();
       });
     });
+    it("read file not in superblock throws", done => {
+      fs.readFile("/not-in-superblock.txt", (err, data) => {
+        expect(err).not.toBe(null);
+        done();
+      });
+    });
     it("read file /a.txt", done => {
       fs.readFile("/a.txt", 'utf8', (err, data) => {
         expect(err).toBe(null);
@@ -79,6 +85,27 @@ describe("http fallback", () => {
             done();
           });
         });
+      });
+    });
+  });
+  describe("backFile", () => {
+    it("backing a nonexistant file throws", done => {
+      fs.backFile("/backFile/non-existant.txt", (err, data) => {
+        expect(err).not.toBe(null);
+        done();
+      });
+    });
+    it("backing a file makes it readable", done => {
+      fs.backFile("/not-in-superblock.txt", (err, data) => {
+        expect(err).toBe(null)
+        fs.readFile("/not-in-superblock.txt", 'utf8', (err, data) => {
+          expect(err).toBe(null);
+          expect(data).toEqual('Hello from "not-in-superblock"');
+          fs.unlink("/not-in-superblock.txt", (err, data) => {
+            expect(err).toBe(null);
+            done();
+          });
+	});
       });
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ module.exports = class FS {
     this.lstat = this.lstat.bind(this)
     this.readlink = this.readlink.bind(this)
     this.symlink = this.symlink.bind(this)
+    this.backFile = this.backFile.bind(this)
   }
   readFile(filepath, opts, cb) {
     const [resolve, reject] = wrapCallback(opts, cb);
@@ -70,5 +71,9 @@ module.exports = class FS {
   symlink(target, filepath, cb) {
     const [resolve, reject] = wrapCallback(cb);
     this.promises.symlink(target, filepath).then(resolve).catch(reject);
+  }
+  backFile(filepath, size, opts, cb) {
+    const [resolve, reject] = wrapCallback(opts, cb);
+    this.promises.backFile(filepath, size, opts).then(resolve).catch(reject);
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -72,8 +72,8 @@ module.exports = class FS {
     const [resolve, reject] = wrapCallback(cb);
     this.promises.symlink(target, filepath).then(resolve).catch(reject);
   }
-  backFile(filepath, size, opts, cb) {
+  backFile(filepath, opts, cb) {
     const [resolve, reject] = wrapCallback(opts, cb);
-    this.promises.backFile(filepath, size, opts).then(resolve).catch(reject);
+    this.promises.backFile(filepath, opts).then(resolve).catch(reject);
   }
 }


### PR DESCRIPTION
Provides for HTTP backing of files when there is no .superblock.txt file or when it is missing content.

These changes allow for a crude alternative to 'dumb' HTTP git remotes as in https://github.com/isomorphic-git/isomorphic-git/issues/672 .  A third-party server folder can now back the filesystem directly and be used as a copy-on-write git store, with this PR and some basic boilerplate such as:
```
let fs = new LightningFS('httpgit', {
	wipe: true,
	url: url,
	urlauto: true
})
let pfs = fs.promises
let packs = await pfs.readFile('/objects/info/packs', { encoding: 'utf8' })
packs = packs.match(/pack-.{40}\.pack/g)
for (let pack of packs) {
	await pfs.backFile('/objects/pack/' + pack.slice(0, 45) + '.idx')
}
git.plugins.set('fs', fs)
```