### PR TITLE
Fix for reading from nested symlinks

### DIFF
--- a/src/CacheFS.js
+++ b/src/CacheFS.js
@@ -108,11 +108,13 @@ module.exports = class CacheFS {
   _lookup(filepath, follow = true) {
     let dir = this._root;
     let partialPath = '/'
-    for (let part of path.split(filepath)) {
+    let parts = path.split(filepath)
+    for (let i = 0; i < parts.length; ++ i) {
+      let part = parts[i];
       dir = dir.get(part);
       if (!dir) throw new ENOENT(filepath);
       // Follow symlinks
-      if (follow) {
+      if (follow || i < parts.length - 1) {
         const stat = dir.get(STAT)
         if (stat.type === 'symlink') {
           let target = stat.target

--- a/src/__tests__/fs.promises.spec.js
+++ b/src/__tests__/fs.promises.spec.js
@@ -430,6 +430,20 @@ describe("fs.promises module", () => {
         });
       });
     });
+    it("readlink operates on paths with symlinks", done => {
+      fs.mkdir("/readlink").finally(() => {
+        fs.symlink("/readlink", "/readlink/sub").then(() => {
+          fs.writeFile("/readlink/c.txt", "hello").then(() => {
+            fs.symlink("/readlink/c.txt", "/readlink/d.txt").then(() => {
+              fs.readlink("/readlink/sub/d.txt").then(data => {
+                expect(data).toBe("/readlink/c.txt")
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
   });
 
 });

--- a/src/__tests__/fs.spec.js
+++ b/src/__tests__/fs.spec.js
@@ -427,6 +427,21 @@ describe("fs module", () => {
         });
       });
     });
+    it("readlink operates on paths with symlinks", done => {
+      fs.mkdir("/readlink", () => {
+        fs.symlink("/readlink", "/readlink/sub", () => {
+          fs.writeFile("/readlink/c.txt", "hello", () => {
+            fs.symlink("/readlink/c.txt", "/readlink/d.txt", () => {
+              fs.readlink("/readlink/sub/d.txt", (err, data) => {
+                expect(err).toBe(null)
+                expect(data).toBe("/readlink/c.txt")
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
   });
 
 });


### PR DESCRIPTION
`CacheFS._lookup` doesn't follow any symlink pathname parts at all when not following symlinks, throwing `ENOENT` if a path is passed containing symlinks.  This means you can't lstat or readlink a link by a path containing symlinks.

This patch adds a fix, dereferencing all path components but the last if `follow` is not set, and adds a test for the bug.