### PR TITLE
fix: a shot in the dark at fixing the "Mutex double-freed" error

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
       BUNDLESIZE_GITHUB_TOKEN: $(BUNDLESIZE_GITHUB_TOKEN)
       SAUCE_ACCESS_KEY: $(SAUCE_ACCESS_KEY)
       SAUCE_USERNAME: $(SAUCE_USERNAME)
-      TEST_BROWSERS: 'ChromeHeadlessNoSandbox,FirefoxHeadless,sl_edge,sl_ios_safari,sl_android_chrome'
+      TEST_BROWSERS: 'ChromeHeadlessNoSandbox,FirefoxHeadless,sl_ios_safari,sl_android_chrome'
 
   - task: PublishTestResults@2
     displayName: 'Save test results'

--- a/src/PromisifiedFS.js
+++ b/src/PromisifiedFS.js
@@ -69,7 +69,7 @@ module.exports = class PromisifiedFS {
     // but there might not be any other fs operations needed until later. Therefore we
     // need to attempt to release the mutex
     this._activate().then(() => {
-      if (this._operations.size === 0) {
+      if (this._operations.size === 0 && !this._deactivationTimeout) {
         this._deactivationTimeout = setTimeout(this._deactivate.bind(this), 100)
       }
     })
@@ -89,6 +89,7 @@ module.exports = class PromisifiedFS {
         this._operations.delete(op)
         if (mutating) this.saveSuperblock() // this is debounced
         if (this._operations.size === 0) {
+          if (!this._deactivationTimeout) clearTimeout(this._deactivationTimeout)
           this._deactivationTimeout = setTimeout(this._deactivate.bind(this), 500)
         }
       }


### PR DESCRIPTION
Somehow, "Mutex double-freed" has occurred ~200 times in production over the last 30 days.

So far the only possibility I see is maybe there is a way that PromisifiedFS can `_deactivate` twice, since `_deactivationTimeout` is written to in two places.

That said, `_deactivate` itself is written to handle concurrency: you could call it 100 times concurrently, and it should only ever call `this._mutex.release()` once. So I don't see how this can fix anything.