### PR TITLE
fix: default mode for symlinks should be 0o120000 not 0x666

### DIFF
--- a/src/CacheFS.js
+++ b/src/CacheFS.js
@@ -228,7 +228,7 @@ module.exports = class CacheFS {
       ino = oldStat.ino;
     } catch (err) {}
     if (mode == null) {
-      mode = 0o666;
+      mode = 0o120000;
     }
     if (ino == null) {
       ino = this.autoinc();

--- a/src/__tests__/fs.spec.js
+++ b/src/__tests__/fs.spec.js
@@ -390,6 +390,19 @@ describe("fs module", () => {
         });
       });
     });
+    it("lstat for symlink creates correct mode", done => {
+      fs.mkdir("/symlink", () => {
+        fs.writeFile("/symlink/a.txt", "hello", () => {
+          fs.symlink("/symlink/a.txt", "/symlink/b.txt", () => {
+            fs.lstat("/symlink/b.txt", (err, stat) => {
+              expect(err).toBe(null)
+              expect(stat.mode).toBe(0o120000)
+							done();
+            });
+          });
+        });
+      });
+    });
     it("lstat doesn't follow symlinks", done => {
       fs.mkdir("/symlink", () => {
         fs.mkdir("/symlink/lstat", () => {


### PR DESCRIPTION
The default mode for symlinks was set to `0o666` which is not correct.

https://unix.superglobalmegacorp.com/Net2/newsrc/sys/stat.h.html#S_IFLNK
`#define	S_IFLNK	 0120000		/* symbolic link */`