### PR TITLE
feat: add custom `backend` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ If that fits your needs, then you can provide a `backend` option and LightningFS
 
 **Note:** If you use a custom backend, you are responsible for managing multi-threaded access - there are no magic mutexes included by default.
 
+Note: throwing an error with the correct `.code` property for any given situation is often important for utilities like `mkdirp` and `rimraf` to work.
+
 ```tsx
 
 type EncodingOpts = {
@@ -230,21 +232,21 @@ type StatLike = {
 
 interface IBackend {
   // highly recommended - usually necessary for apps to work
-  readFile(filepath: string, opts: EncodingOpts): Awaited<Uint8Array | string>;
-  writeFile(filepath: string, data: Uint8Array | string, opts: EncodingOpts): void;
-  unlink(filepath: string, opts: any): void;
-  readdir(filepath: string, opts: any): Awaited<string[]>;
-  mkdir(filepath: string, opts: any): void;
-  rmdir(filepath: string, opts: any): void;
+  readFile(filepath: string, opts: EncodingOpts): Awaited<Uint8Array | string>; // throws ENOENT
+  writeFile(filepath: string, data: Uint8Array | string, opts: EncodingOpts): void; // throws ENOENT
+  unlink(filepath: string, opts: any): void; // throws ENOENT
+  readdir(filepath: string, opts: any): Awaited<string[]>; // throws ENOENT, ENOTDIR
+  mkdir(filepath: string, opts: any): void; // throws ENOENT, EEXIST
+  rmdir(filepath: string, opts: any): void; // throws ENOENT, ENOTDIR, ENOTEMPTY
 
   // recommended - often necessary for apps to work
-  stat(filepath: string, opts: any): Awaited<StatLike>;
-  lstat(filepath: string, opts: any): Awaited<StatLike>;
+  stat(filepath: string, opts: any): Awaited<StatLike>; // throws ENOENT
+  lstat(filepath: string, opts: any): Awaited<StatLike>; // throws ENOENT
 
   // suggested - used occasionally by apps
-  rename(oldFilepath: string, newFilepath: string): void;
-  readlink(filepath: string, opts: any): Awaited<string>;
-  symlink(target: string, filepath: string): void;
+  rename(oldFilepath: string, newFilepath: string): void; // throws ENOENT
+  readlink(filepath: string, opts: any): Awaited<string>; // throws ENOENT
+  symlink(target: string, filepath: string): void; // throws ENOENT
 
   // bonus - not part of the standard `fs` module
   backFile(filepath: string, opts: any): void;

--- a/src/DefaultBackend.js
+++ b/src/DefaultBackend.js
@@ -1,0 +1,180 @@
+const { encode, decode } = require("isomorphic-textencoder");
+const debounce = require("just-debounce-it");
+
+const CacheFS = require("./CacheFS.js");
+const { ENOENT, ENOTEMPTY, ETIMEDOUT } = require("./errors.js");
+const IdbBackend = require("./IdbBackend.js");
+const HttpBackend = require("./HttpBackend.js")
+const Mutex = require("./Mutex.js");
+const Mutex2 = require("./Mutex2.js");
+
+const path = require("./path.js");
+
+module.exports = class DefaultBackend {
+  constructor() {
+    this.saveSuperblock = debounce(() => {
+      this._saveSuperblock();
+    }, 500);
+  }
+  async init (name, {
+    wipe,
+    url,
+    urlauto,
+    fileDbName = name,
+    fileStoreName = name + "_files",
+    lockDbName = name + "_lock",
+    lockStoreName = name + "_lock",
+  } = {}) {
+    this._name = name
+    this._idb = new IdbBackend(fileDbName, fileStoreName);
+    this._mutex = navigator.locks ? new Mutex2(name) : new Mutex(lockDbName, lockStoreName);
+    this._cache = new CacheFS(name);
+    this._opts = { wipe, url };
+    this._needsWipe = !!wipe;
+    if (url) {
+      this._http = new HttpBackend(url)
+      this._urlauto = !!urlauto
+    }
+  }
+  async activate() {
+    if (this._cache.activated) return
+    // Wipe IDB if requested
+    if (this._needsWipe) {
+      this._needsWipe = false;
+      await this._idb.wipe()
+      await this._mutex.release({ force: true })
+    }
+    if (!(await this._mutex.has())) await this._mutex.wait()
+    // Attempt to load FS from IDB backend
+    const root = await this._idb.loadSuperblock()
+    if (root) {
+      this._cache.activate(root);
+    } else if (this._http) {
+      // If that failed, attempt to load FS from HTTP backend
+      const text = await this._http.loadSuperblock()
+      this._cache.activate(text)
+      await this._saveSuperblock();
+    } else {
+      // If there is no HTTP backend, start with an empty filesystem
+      this._cache.activate()
+    }
+    if (await this._mutex.has()) {
+      return
+    } else {
+      throw new ETIMEDOUT()
+    }
+  }
+  async deactivate() {
+    if (await this._mutex.has()) {
+      await this._saveSuperblock()
+    }
+    this._cache.deactivate()
+    try {
+      await this._mutex.release()
+    } catch (e) {
+      console.log(e)
+    }
+    await this._idb.close()
+  }
+  async _saveSuperblock() {
+    if (this._cache.activated) {
+      this._lastSavedAt = Date.now()
+      await this._idb.saveSuperblock(this._cache._root);
+    }
+  }
+  async _writeStat(filepath, size, opts) {
+    let dirparts = path.split(path.dirname(filepath))
+    let dir = dirparts.shift()
+    for (let dirpart of dirparts) {
+      dir = path.join(dir, dirpart)
+      try {
+        this._cache.mkdir(dir, { mode: 0o777 })
+      } catch (e) {}
+    }
+    return this._cache.writeStat(filepath, size, opts)
+  }
+  async readFile(filepath, opts) {
+    const { encoding } = opts;
+    if (encoding && encoding !== 'utf8') throw new Error('Only "utf8" encoding is supported in readFile');
+    let data = null, stat = null
+    try {
+      stat = this._cache.stat(filepath);
+      data = await this._idb.readFile(stat.ino)
+    } catch (e) {
+      if (!this._urlauto) throw e
+    }
+    if (!data && this._http) {
+      let lstat = this._cache.lstat(filepath)
+      while (lstat.type === 'symlink') {
+        filepath = path.resolve(path.dirname(filepath), lstat.target)
+        lstat = this._cache.lstat(filepath)
+      }
+      data = await this._http.readFile(filepath)
+    }
+    if (data) {
+      if (!stat || stat.size != data.byteLength) {
+        stat = await this._writeStat(filepath, data.byteLength, { mode: stat ? stat.mode : 0o666 })
+        this.saveSuperblock() // debounced
+      }
+      if (encoding === "utf8") {
+        data = decode(data);
+      }
+    }
+    if (!stat) throw new ENOENT(filepath)
+    return data;
+  }
+  async writeFile(filepath, data, opts) {
+    const { mode, encoding = "utf8" } = opts;
+    if (typeof data === "string") {
+      if (encoding !== "utf8") {
+        throw new Error('Only "utf8" encoding is supported in writeFile');
+      }
+      data = encode(data);
+    }
+    const stat = await this._cache.writeStat(filepath, data.byteLength, { mode });
+    await this._idb.writeFile(stat.ino, data)
+  }
+  async unlink(filepath, opts) {
+    const stat = this._cache.lstat(filepath);
+    this._cache.unlink(filepath);
+    if (stat.type !== 'symlink') {
+      await this._idb.unlink(stat.ino)
+    }
+  }
+  async readdir(filepath, opts) {
+    return this._cache.readdir(filepath);
+  }
+  async mkdir(filepath, opts) {
+    const { mode = 0o777 } = opts;
+    await this._cache.mkdir(filepath, { mode });
+  }
+  async rmdir(filepath, opts) {
+    // Never allow deleting the root directory.
+    if (filepath === "/") {
+      throw new ENOTEMPTY();
+    }
+    this._cache.rmdir(filepath);
+  }
+  async rename(oldFilepath, newFilepath) {
+    this._cache.rename(oldFilepath, newFilepath);
+  }
+  async stat(filepath, opts) {
+    return this._cache.stat(filepath);
+  }
+  async lstat(filepath, opts) {
+    return this._cache.lstat(filepath);
+  }
+  async readlink(filepath, opts) {
+    return this._cache.readlink(filepath);
+  }
+  async symlink(target, filepath) {
+    this._cache.symlink(target, filepath);
+  }
+  async backFile(filepath, opts) {
+    let size = await this._http.sizeFile(filepath)
+    await this._writeStat(filepath, size, opts)
+  }
+  async du(filepath) {
+    return this._cache.du(filepath);
+  }
+}

--- a/src/DefaultBackend.js
+++ b/src/DefaultBackend.js
@@ -82,7 +82,7 @@ module.exports = class DefaultBackend {
       await this._idb.saveSuperblock(this._cache._root);
     }
   }
-  async _writeStat(filepath, size, opts) {
+  _writeStat(filepath, size, opts) {
     let dirparts = path.split(path.dirname(filepath))
     let dir = dirparts.shift()
     for (let dirpart of dirparts) {
@@ -141,40 +141,40 @@ module.exports = class DefaultBackend {
       await this._idb.unlink(stat.ino)
     }
   }
-  async readdir(filepath, opts) {
+  readdir(filepath, opts) {
     return this._cache.readdir(filepath);
   }
-  async mkdir(filepath, opts) {
+  mkdir(filepath, opts) {
     const { mode = 0o777 } = opts;
-    await this._cache.mkdir(filepath, { mode });
+    this._cache.mkdir(filepath, { mode });
   }
-  async rmdir(filepath, opts) {
+  rmdir(filepath, opts) {
     // Never allow deleting the root directory.
     if (filepath === "/") {
       throw new ENOTEMPTY();
     }
     this._cache.rmdir(filepath);
   }
-  async rename(oldFilepath, newFilepath) {
+  rename(oldFilepath, newFilepath) {
     this._cache.rename(oldFilepath, newFilepath);
   }
-  async stat(filepath, opts) {
+  stat(filepath, opts) {
     return this._cache.stat(filepath);
   }
-  async lstat(filepath, opts) {
+  lstat(filepath, opts) {
     return this._cache.lstat(filepath);
   }
-  async readlink(filepath, opts) {
+  readlink(filepath, opts) {
     return this._cache.readlink(filepath);
   }
-  async symlink(target, filepath) {
+  symlink(target, filepath) {
     this._cache.symlink(target, filepath);
   }
   async backFile(filepath, opts) {
     let size = await this._http.sizeFile(filepath)
     await this._writeStat(filepath, size, opts)
   }
-  async du(filepath) {
+  du(filepath) {
     return this._cache.du(filepath);
   }
 }

--- a/src/PromisifiedFS.js
+++ b/src/PromisifiedFS.js
@@ -40,31 +40,23 @@ function cleanParamsFilepathFilepath(oldFilepath, newFilepath, ...rest) {
   return [path.normalize(oldFilepath), path.normalize(newFilepath), ...rest];
 }
 
-module.exports = function promises(name, options) {
-  const pfs = new PromisifiedFS(options);
-  pfs.init = pfs.init.bind(pfs)
-  pfs.readFile = pfs._wrap(pfs.readFile, cleanParamsFilepathOpts, false)
-  pfs.writeFile = pfs._wrap(pfs.writeFile, cleanParamsFilepathDataOpts, true)
-  pfs.unlink = pfs._wrap(pfs.unlink, cleanParamsFilepathOpts, true)
-  pfs.readdir = pfs._wrap(pfs.readdir, cleanParamsFilepathOpts, false)
-  pfs.mkdir = pfs._wrap(pfs.mkdir, cleanParamsFilepathOpts, true)
-  pfs.rmdir = pfs._wrap(pfs.rmdir, cleanParamsFilepathOpts, true)
-  pfs.rename = pfs._wrap(pfs.rename, cleanParamsFilepathFilepath, true)
-  pfs.stat = pfs._wrap(pfs.stat, cleanParamsFilepathOpts, false)
-  pfs.lstat = pfs._wrap(pfs.lstat, cleanParamsFilepathOpts, false)
-  pfs.readlink = pfs._wrap(pfs.readlink, cleanParamsFilepathOpts, false)
-  pfs.symlink = pfs._wrap(pfs.symlink, cleanParamsFilepathFilepath, true)
-  pfs.backFile = pfs._wrap(pfs.backFile, cleanParamsFilepathOpts, true)
-  pfs.du = pfs._wrap(pfs.du, cleanParamsFilepathOpts, false);
+module.exports = class PromisifiedFS {
+  constructor(name, options = {}) {
+    this.init = this.init.bind(this)
+    this.readFile = this._wrap(this.readFile, cleanParamsFilepathOpts, false)
+    this.writeFile = this._wrap(this.writeFile, cleanParamsFilepathDataOpts, true)
+    this.unlink = this._wrap(this.unlink, cleanParamsFilepathOpts, true)
+    this.readdir = this._wrap(this.readdir, cleanParamsFilepathOpts, false)
+    this.mkdir = this._wrap(this.mkdir, cleanParamsFilepathOpts, true)
+    this.rmdir = this._wrap(this.rmdir, cleanParamsFilepathOpts, true)
+    this.rename = this._wrap(this.rename, cleanParamsFilepathFilepath, true)
+    this.stat = this._wrap(this.stat, cleanParamsFilepathOpts, false)
+    this.lstat = this._wrap(this.lstat, cleanParamsFilepathOpts, false)
+    this.readlink = this._wrap(this.readlink, cleanParamsFilepathOpts, false)
+    this.symlink = this._wrap(this.symlink, cleanParamsFilepathFilepath, true)
+    this.backFile = this._wrap(this.backFile, cleanParamsFilepathOpts, true)
+    this.du = this._wrap(this.du, cleanParamsFilepathOpts, false);
 
-  if (name) {
-    pfs.init(name, options)
-  }
-  return pfs;
-}
-
-class PromisifiedFS {
-  constructor(options = {}) {
     this._backend = options.backend || new DefaultBackend();
 
     this._deactivationPromise = null
@@ -72,6 +64,10 @@ class PromisifiedFS {
     this._activationPromise = null
 
     this._operations = new Set()
+
+    if (name) {
+      this.init(name, options)
+    }
   }
   async init (...args) {
     if (this._initPromiseResolve) await this._initPromise;

--- a/src/PromisifiedFS.js
+++ b/src/PromisifiedFS.js
@@ -83,6 +83,14 @@ module.exports = class PromisifiedFS {
       this._initPromiseResolve();
       this._initPromiseResolve = null;
     }
+    // The next comment starting with the "fs is initially activated when constructed"?
+    // That can create contention for the mutex if two threads try to init at the same time
+    // so I've added an option to disable that behavior.
+    if (!options.defer) {
+      // The fs is initially activated when constructed (in order to wipe/save the superblock)
+      // This is not awaited, because that would create a cycle.
+      this.stat('/')
+    }
   }
   async _gracefulShutdown () {
     if (this._operations.size > 0) {

--- a/src/__tests__/fallback.spec.js
+++ b/src/__tests__/fallback.spec.js
@@ -4,7 +4,7 @@ const fs = new FS("fallbackfs", { wipe: true, url: 'http://localhost:9876/base/s
 
 describe("http fallback", () => {
   it("sanity check", () => {
-    expect(fs.promises._http).not.toBeFalsy()
+    expect(fs.promises._backend._http).not.toBeFalsy()
   })
   it("loads", (done) => {
     fs.promises._activate().then(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const once = require("just-once");
 
-const PromisifiedFS = require('./PromisifiedFS');
+const promises = require('./PromisifiedFS');
 
 function wrapCallback (opts, cb) {
   if (typeof opts === "function") {
@@ -13,7 +13,7 @@ function wrapCallback (opts, cb) {
 
 module.exports = class FS {
   constructor(...args) {
-    this.promises = new PromisifiedFS(...args)
+    this.promises = promises(...args)
     // Needed so things don't break if you destructure fs and pass individual functions around
     this.init = this.init.bind(this)
     this.readFile = this.readFile.bind(this)

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const once = require("just-once");
 
-const promises = require('./PromisifiedFS');
+const PromisifiedFS = require('./PromisifiedFS');
 
 function wrapCallback (opts, cb) {
   if (typeof opts === "function") {
@@ -13,7 +13,7 @@ function wrapCallback (opts, cb) {
 
 module.exports = class FS {
   constructor(...args) {
-    this.promises = promises(...args)
+    this.promises = new PromisifiedFS(...args)
     // Needed so things don't break if you destructure fs and pass individual functions around
     this.init = this.init.bind(this)
     this.readFile = this.readFile.bind(this)


### PR DESCRIPTION
The goal here is to allow benefiting from the normalization features of lightning-fs, without actually using the storage and retrieval mechanisms of lightning-fs. WIP.