### PR TITLE
Fix exports in type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -287,7 +287,7 @@ declare module '@isomorphic-git/lightning-fs' {
       mode: number
     }
   }
-  export default FS
+  export = FS
 }
 
 declare module '@isomorphic-git/lightning-fs/src/path' {
@@ -299,5 +299,5 @@ declare module '@isomorphic-git/lightning-fs/src/path' {
     function dirname(path: string): string
     function resolve(...paths: string[]): string
   }
-  export default Path
+  export = Path
 }


### PR DESCRIPTION
Since the code uses `module.exports = ...`, the TypeScript types should use `export = ...` to match. This ensures it works when neither `esModuleInterop` nor `allowSyntheticDefaultImports` are enabled.

For more context, see https://github.com/DefinitelyTyped/DefinitelyTyped#a-package-uses-export--but-i-prefer-to-use-default-imports-can-i-change-export--to-export-default