### PR TITLE
Include types in npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "**/*.js",
+    "index.d.ts",
     "!__tests__",
     "!coverage"
   ],


### PR DESCRIPTION
Since package.json includes a "files" key, only the files included in it will be included when installing via npm. The new types won't get picked up by npm unless we add it to the allowlist.