### PR TITLE
add to change low level backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Options object:
 | `lockDbName`    | string             | Customize the database name for the lock mutex                                                                                                                                             |
 | `lockStoreName` | string             | Customize the store name for the lock mutex                                                                                                                                                |
 | `defer`         | boolean = false    | If true, avoids mutex contention during initialization                                                                                                                                     |
+| `db`            | IDB                | Replacement for DB object that hold Filesystem data. It's low level replacement for `backend` option.  |
 | `backend`       | IBackend           | If present, none of the other arguments (except `defer`) have any effect, and instead of using the normal LightningFS stuff, LightningFS acts as a wrapper around the provided custom backend. |
+
 
 #### Advanced usage
 
@@ -258,6 +260,17 @@ interface IBackend {
   deactivate?(): Awaited<void>; // called after fs has been idle for a while
   destroy?(): Awaited<void>; // called before hotswapping backends
 }
+
+interface IDB {
+  saveSuperblock(superblock): void;
+  loadSuperblock(): Awaited<Buffer>;
+  readFile(inode): Awaited<Buffer>;
+  writeFile(inode, data): Awaited<void>;
+  unlink(inode): Awaited<void>;
+  wipe(): void;
+  close(): void;
+}
+
 ```
 
 ## License

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,12 +2,12 @@ jobs:
 - job: Linux
 
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: 'Ubuntu 18.04'
 
   steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '10.x'
+      versionSpec: '12.x'
     displayName: 'Install Node.js'
 
   - script: npm ci

--- a/src/DefaultBackend.js
+++ b/src/DefaultBackend.js
@@ -119,6 +119,8 @@ module.exports = class DefaultBackend {
       }
       if (encoding === "utf8") {
         data = decode(data);
+      } else {
+        data.toString = () => decode(data);
       }
     }
     if (!stat) throw new ENOENT(filepath)

--- a/src/DefaultBackend.js
+++ b/src/DefaultBackend.js
@@ -21,12 +21,13 @@ module.exports = class DefaultBackend {
     url,
     urlauto,
     fileDbName = name,
+    db = null,
     fileStoreName = name + "_files",
     lockDbName = name + "_lock",
     lockStoreName = name + "_lock",
   } = {}) {
     this._name = name
-    this._idb = new IdbBackend(fileDbName, fileStoreName);
+    this._idb = db || new IdbBackend(fileDbName, fileStoreName);
     this._mutex = navigator.locks ? new Mutex2(name) : new Mutex(lockDbName, lockStoreName);
     this._cache = new CacheFS(name);
     this._opts = { wipe, url };


### PR DESCRIPTION
This is a replacement for #49

My test example:

```javascript
class MemoryBackend {
  constructor() {
    this._store = new Map();
  }
  saveSuperblock(superblock) {
    this._store.set("!root", superblock)
  }
  loadSuperblock() {
    return this._store.get("!root")
  }
  readFile(inode) {
    return this._store.get(inode)
  }
  writeFile(inode, data) {
    return this._store.set(inode, data)
  }
  unlink(inode) {
    return this._store.delete(inode)
  }
  wipe() {
    this._store = new Map()
  }
  close() {
    
  }
}

var fs = new LightningFS("fs", { db: new MemoryBackend() });

(async () => {

    await fs.promises.writeFile('/foo', 'hello');
    const file = await fs.promises.readFile('/foo');
    console.log(file.toString());

})();
```