### PR TITLE
add fs.flush() that saves superblock

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -206,6 +206,11 @@ declare module '@isomorphic-git/lightning-fs' {
        * @returns The size of a file or directory in bytes.
        */
       du(filepath: string): Promise<number>
+      /**
+       * Function that saves anything that need to be saved in IndexedBD or custom IDB object. Right now it saves SuperBlock so it's save to dump the object as dump it into a file (e.g. from a Browser)
+       * @returns Promise that resolves when super block is saved to file
+       */
+       flush(): Promise<void>
     }
 
     export interface Options {
@@ -245,8 +250,19 @@ declare module '@isomorphic-git/lightning-fs' {
        * @default false
        */
       defer?: boolean
-
+      db: FS.IDB
     }
+    export interface IDB {
+      constructor(dbname: string, storename: string): IDB
+      saveSuperblock(sb: Uint8Array): TypeOrPromise<void>
+      loadSuperblock(): TypeOrPromise<FS.SuperBlock>
+      loadFile(inode: number): TypeOrPromise<Uint8Array>
+      writeFile(inode: number, data: Uint8Array): TypeOrPromise<void>
+      wipe(): TypeOrPromise<void>
+      close(): TypeOrPromise<void>
+    }
+    type TypeOrPromise<T> = T | Promise<T>
+    export type SuperBlock = Map<string | number, any>
     export interface MKDirOptions {
       /**
        * Posix mode permissions

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "**/*.js",
+    "index.d.ts",
     "!__tests__",
     "!coverage"
   ],

--- a/src/DefaultBackend.js
+++ b/src/DefaultBackend.js
@@ -13,7 +13,7 @@ const path = require("./path.js");
 module.exports = class DefaultBackend {
   constructor() {
     this.saveSuperblock = debounce(() => {
-      this._saveSuperblock();
+      this.flush();
     }, 500);
   }
   async init (name, {
@@ -179,5 +179,8 @@ module.exports = class DefaultBackend {
   }
   du(filepath) {
     return this._cache.du(filepath);
+  }
+  flush() {
+    return this._saveSuperblock();
   }
 }

--- a/src/PromisifiedFS.js
+++ b/src/PromisifiedFS.js
@@ -198,4 +198,7 @@ module.exports = class PromisifiedFS {
   async du(filepath) {
     return this._backend.du(filepath);
   }
+  async flush() {
+    return this._backend.flush();
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ module.exports = class FS {
     this.symlink = this.symlink.bind(this)
     this.backFile = this.backFile.bind(this)
     this.du = this.du.bind(this)
+    this.flush = this.flush.bind(this)
   }
   init(name, options) {
     return this.promises.init(name, options)
@@ -84,5 +85,9 @@ module.exports = class FS {
   du(filepath, cb) {
     const [resolve, reject] = wrapCallback(cb);
     this.promises.du(filepath).then(resolve).catch(reject);
+  }
+  flush(cb) {
+    const [resolve, reject] = wrapCallback(cb);
+    this.promises.flush().then(resolve).catch(reject);
   }
 }


### PR DESCRIPTION
This will allow writing the `dump()` function for IDB, which will save the whole IDB into JSON and later load it into memory (like Filesystem Images).

Without flush users have no control when superBlock is saved to IDB.