### PR TITLE
Making `db` as optional for `Options` interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -252,7 +252,11 @@ declare module '@isomorphic-git/lightning-fs' {
        * @default false
        */
       defer?: boolean
-      db: FS.IDB
+      /**
+       * Custom database instance
+       * @default null
+       */
+      db?: FS.IDB
     }
     export interface IDB {
       constructor(dbname: string, storename: string): IDB


### PR DESCRIPTION
The `db` is actually optional, as if it’s not present, it’ll default to the db creation, so the type should be optional too.