### PR TITLE
Remove constructor from IDB interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -259,7 +259,6 @@ declare module '@isomorphic-git/lightning-fs' {
       db?: FS.IDB
     }
     export interface IDB {
-      constructor(dbname: string, storename: string): IDB
       saveSuperblock(sb: Uint8Array): TypeOrPromise<void>
       loadSuperblock(): TypeOrPromise<FS.SuperBlock>
       loadFile(inode: number): TypeOrPromise<Uint8Array>


### PR DESCRIPTION
Interfaces shouldn't specify constructor types.
Moreover, I'm pretty sure [it's not possible to implement this interface](https://stackoverflow.com/a/46977622).