### PR TITLE
fix: fix required delay after init

### DIFF
--- a/src/PromisifiedFS.js
+++ b/src/PromisifiedFS.js
@@ -94,7 +94,7 @@ module.exports = class PromisifiedFS {
     if (!options.defer) {
       // The fs is initially activated when constructed (in order to wipe/save the superblock)
       // This is not awaited, because that would create a cycle.
-      this.stat('/')
+      this._deactivate()
     }
   }
   async _gracefulShutdown () {


### PR DESCRIPTION
This fixes the forced delay to deactivate the FS.

The old code was using a side effect of calling `stat('/')`. After the fix it call `deactivate` directly which makes it so the code that uses lighthingFS don't need to put a 500ms delay after init.