### PR TITLE
Fix IDB interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -259,10 +259,9 @@ declare module '@isomorphic-git/lightning-fs' {
       db?: FS.IDB
     }
     export interface IDB {
-      constructor(dbname: string, storename: string): IDB
       saveSuperblock(sb: Uint8Array): TypeOrPromise<void>
       loadSuperblock(): TypeOrPromise<FS.SuperBlock>
-      loadFile(inode: number): TypeOrPromise<Uint8Array>
+      readFile(inode: number): TypeOrPromise<Uint8Array>
       writeFile(inode: number, data: Uint8Array): TypeOrPromise<void>
       wipe(): TypeOrPromise<void>
       close(): TypeOrPromise<void>


### PR DESCRIPTION
Fixing #126 

1. Removed the `constructor(...)` method from the interface. When user provides a custom `db` instance, the constructor is never invoked by the lightning-fs so constraining it in the interface is unnecessary. Please confirm this though. In addition, if we want to constrain the constructor interface, (for whatever reason), a different setup is required. See: https://stackoverflow.com/questions/13407036/how-does-interfaces-with-construct-signatures-work
2. Renamed `loadFile` to `readFile`, matching implemention.